### PR TITLE
Update Resource Groups console arrangement and note to enable Inspector

### DIFF
--- a/docs/module1/index.md
+++ b/docs/module1/index.md
@@ -79,15 +79,14 @@ You can use resource groups to organize your AWS resources. Resource groups make
 
 To work with resource groups on the AWS Management Console home
 
-1. Sign in to the AWS Management Console and go to AWS Systems Manager.
-2. On the navigation bar under **Application Management**, choose **Resource Groups**.
-3. On the Resource Groups page click **Create a resource group**
-4. Select AWS::EC2::Instance with the Key-Value pair of Owner and the owner name of the instances you want to group together. Typically this might be an application-ID or layer in the stack such as Web Server, App Servers, etc.
-5. Enter a Group name for the resources you are creating a group for. Suggested name would be something like prod-Application-xyz, dev-BusinessUnit-abc.
+1. Sign in to the AWS Management Console and go to AWS Resource Groups.
+2. On the Resource Groups page click **Create Resource Group**
+3. Under **Grouping Criteria**, select the AWS::EC2::Instance *Resource type* with the *Tags* key-value pair of *Owner* and the owner name of the instances you want to group together (you made a note of this value above). Typically, this is an application-ID or layer in the stack such as Web Server, App Servers, etc.
+4. Under **Group details**, enter a *Group name* for the resources you are creating a group for. A suggested name would be something like prod-Application-xyz, dev-BusinessUnit-abc.
 
 	![findresources](images/findresources.png)
 
-6. Click **Create Group**. You can now find your group under the Saved Resource Groups in the Navigation bar.
+5. Click **Create Group**. You can now find your group under the Saved Resource Groups in the Navigation bar.
 
 ## Takeaway
 

--- a/docs/module2/index.md
+++ b/docs/module2/index.md
@@ -77,6 +77,8 @@ ContinuousInspectionScheduledRule | The CloudWatch Events rule that executes con
 BucketName | The name of the Amazon S3 bucket in which you need to upload CloudFormation Template for launching your golden AMI
 ContinuousAssessmentResultsTopic | The SNS topic on which continuous assessment results will be published
 
+!!! warning "Before executing the Systems Manager Automation below, ensure that **Amazon Inspector** is enabled in your account in the Ohio region. If you don't have Inspector enabled, you will still receive the assessment results via email, but you won't be able to examine them in the console."
+
 ### Create a golden AMI
 
 1. Navigate to **Systems Manager** console


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Resource Groups are now listed separately in the AWS console from Systems Manager.

AWS Inspector is not enabled by default, and will not display assessment results if it is not enabled prior to execution of the automation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
